### PR TITLE
Fixed bug: no landing time when clicking on active planet

### DIFF
--- a/src/components/stations.js
+++ b/src/components/stations.js
@@ -64,6 +64,10 @@ function Stations(el, context) {
           return;
         }
 
+        if (div.classList.contains('active')) {
+          return;
+        }
+
         // Otherwise they wanted to login
         div.send('station:login', { station: i });
       }


### PR DESCRIPTION
When you're on a planet and click on the active planet there's no landing time